### PR TITLE
use distroless base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
-FROM golang:1.13.0
+FROM golang:1.13-buster as builder
 MAINTAINER "Gian Marco Mennecozzi"
 WORKDIR /haaukins
 
 COPY . .
 RUN go build -o server .
+
+FROM gcr.io/distroless/base-debian10
+COPY --from=builder /haaukins /
 EXPOSE 50051
-CMD ["./server"]
+CMD ["/server"]


### PR DESCRIPTION
I am suggesting to use smallest docker base image possible, I can summarize that  what this commit will do is following ; 

From this one ; 

<img width="878" alt="Screenshot 2020-05-24 at 16 20 06" src="https://user-images.githubusercontent.com/13614433/82755397-dda1f980-9ddb-11ea-886d-01be3b68d40f.png">

INTO this one; 

<img width="905" alt="Screenshot 2020-05-24 at 16 24 18" src="https://user-images.githubusercontent.com/13614433/82755403-e8f52500-9ddb-11ea-862b-e471458ae413.png">

It is reduced almost ~ 30 times.  ⚔️ 🦾

Signed-off-by: Ahmet Turkmen <f.ahmet.turkmen@icloud.com>